### PR TITLE
Feature/owl pretty print

### DIFF
--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -1,6 +1,7 @@
 import gavel.logic.logic as fol
 from gavel.dialects.base.compiler import Compiler
 from gavel.logic import problem
+import re
 
 
 class TPTPCompiler(Compiler):
@@ -187,13 +188,13 @@ class TPTPCompiler(Compiler):
 
     def visit_functor_expression(self, expression: fol.FunctorExpression):
         return "{}({})".format(
-            self.visit(expression.functor),
+            self.visit("f" + re.sub("[^A-z_0-9]", "_", expression.functor)),
             ",".join(map(self.visit, expression.arguments)),
         )
 
     def visit_predicate_expression(self, expression: fol.PredicateExpression):
         return "{}({})".format(
-            self.visit(expression.predicate),
+            self.visit("P" + re.sub("[^A-z_0-9]", "_", expression.predicate)),
             ",".join(map(self.visit, expression.arguments)),
         )
 
@@ -233,13 +234,13 @@ class TPTPCompiler(Compiler):
         return "{}>{}".format(self.visit(expression.left), self.visit(expression.right))
 
     def visit_variable(self, variable: fol.Variable):
-        return variable.symbol
+        return "V" + re.sub("[^A-z_0-9]", "_", variable.symbol)
 
     def visit_distinct_object(self, variable: fol.DistinctObject):
         return "\"" + variable.symbol + "\""
 
     def visit_constant(self, variable: fol.Variable):
-        return variable.symbol
+        return "c" + re.sub("[^A-z_0-9]", "_", variable.symbol)
 
     def visit_problem(self, problem: problem.Problem):
         L = [self.visit(i) for i in problem.imports] + [self.visit(axiom) for axiom in problem.premises] + [self.visit(c) for c in problem.conjectures]

--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -188,13 +188,15 @@ class TPTPCompiler(Compiler):
 
     def visit_functor_expression(self, expression: fol.FunctorExpression):
         return "{}({})".format(
-            self.visit("f" + re.sub("[^A-z_0-9]", "_", expression.functor)),
+            self.visit(re.sub("[^A-z_0-9]", "_", expression.functor[:1].lower()
+                                                 + expression.functor[1:] if expression.functor else "")),
             ",".join(map(self.visit, expression.arguments)),
         )
 
     def visit_predicate_expression(self, expression: fol.PredicateExpression):
         return "{}({})".format(
-            self.visit("P" + re.sub("[^A-z_0-9]", "_", expression.predicate)),
+            self.visit(re.sub("[^A-z_0-9]", "_", expression.predicate[:1].lower()
+                                                 + expression.predicate[1:] if expression.predicate else "")),
             ",".join(map(self.visit, expression.arguments)),
         )
 
@@ -234,13 +236,15 @@ class TPTPCompiler(Compiler):
         return "{}>{}".format(self.visit(expression.left), self.visit(expression.right))
 
     def visit_variable(self, variable: fol.Variable):
-        return "V" + re.sub("[^A-z_0-9]", "_", variable.symbol)
+        return re.sub("[^A-z_0-9]", "_", variable.symbol[:1].upper()
+                                                 + variable.symbol[1:] if variable.symbol else "")
 
     def visit_distinct_object(self, variable: fol.DistinctObject):
         return "\"" + variable.symbol + "\""
 
     def visit_constant(self, variable: fol.Variable):
-        return "c" + re.sub("[^A-z_0-9]", "_", variable.symbol)
+        return re.sub("[^A-z_0-9]", "_", variable.symbol[:1].lower()
+                                                 + variable.symbol[1:] if variable.symbol else "")
 
     def visit_problem(self, problem: problem.Problem):
         L = [self.visit(i) for i in problem.imports] + [self.visit(axiom) for axiom in problem.premises] + [self.visit(c) for c in problem.conjectures]


### PR DESCRIPTION
These changes allow the TPTP compiler to transform names into ones that are in correct TPTP syntax. 
This is necessary so that gavel-owl can leave the entity names unchanged while translating from OWL to FOL.