### PR TITLE
use parse from file method

### DIFF
--- a/src/gavel/cli.py
+++ b/src/gavel/cli.py
@@ -80,11 +80,9 @@ def translate(ctx, frm, to, path, save):
     #if the parameter save is specified, the translation gets saved as a file with that name
     if save != "":
         with open(str(save) + '.txt', 'w') as file:
-            with open(path, "r") as finp:
-                file.write(compiler.visit(parser.parse(finp.read(), **kwargs)))
+            file.write(compiler.visit(parser.parse_from_file(path, **kwargs)))
     else:
-        with open(path, "r") as finp:
-            print(compiler.visit(parser.parse(finp.read(), **kwargs)))
+        print(compiler.visit(parser.parse_from_file(path, **kwargs)))
 
 
 def add_source(source):

--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -161,8 +161,8 @@ class TPTPCompiler(Compiler):
         )
 
     def visit_annotated_formula(self, anno: problem.AnnotatedFormula):
-        return "{}({},{},({} # {})).".format(
-            anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula), anno.annotation
+        return "{}({},{},({})).".format(
+            anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula)
         )
 
     def visit_binary_formula(self, formula: fol.BinaryFormula, parent_operand=None):

--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -162,7 +162,7 @@ class TPTPCompiler(Compiler):
 
     def visit_annotated_formula(self, anno: problem.AnnotatedFormula):
         return "{}({},{},({} # {})).".format(
-            anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula), self.visit(anno.annotation)
+            anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula), anno.annotation
         )
 
     def visit_binary_formula(self, formula: fol.BinaryFormula, parent_operand=None):

--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -161,8 +161,8 @@ class TPTPCompiler(Compiler):
         )
 
     def visit_annotated_formula(self, anno: problem.AnnotatedFormula):
-        return "{}({},{},({})).".format(
-            anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula)
+        return "{}({},{},({} # {})).".format(
+            anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula), self.visit(anno.annotation)
         )
 
     def visit_binary_formula(self, formula: fol.BinaryFormula, parent_operand=None):


### PR DESCRIPTION
In the translation function, I replaced the `parse`-call with a `parse_from_file`-call. This is helpful for gavel-owl, where the parse function fails for large files (e.g. ChEBI). For other parsers where `parse_from_file` is not implemented, `parse_from_file` calls `parse` by default.