### PR TITLE
support for fowl dialect annotated-owl

### DIFF
--- a/src/gavel/cli.py
+++ b/src/gavel/cli.py
@@ -71,8 +71,9 @@ def prove(p, f, s, plot, hets):
 @click.argument("path")
 @click.option("--save", "-s", metavar="SAVE_PATH", default="", help="If set, saves the translation to SAVE_PATH")
 @click.option("--shorten-names", "-n", is_flag=True, help="Shorten names in output language (only for TPTP)")
+@click.option("--no-annotations", "-a", is_flag=True, help="Remove annotations in output dialect")
 @click.pass_context
-def translate(ctx, frm, to, path, save, shorten_names):
+def translate(ctx, frm, to, path, save, shorten_names, no_annotations):
     """
     Translates the file at PATH from the dialect specified by FRM to the dialect TO. You can get a list of all available dialects via the `dialects` command.
 
@@ -102,7 +103,8 @@ def translate(ctx, frm, to, path, save, shorten_names):
     output_dialect = get_dialect(to)
 
     parser = input_dialect._parser_cls()
-    compiler = output_dialect._compiler_cls(shorten_names=(to == TPTPDialect._identifier() and shorten_names))
+    compiler = output_dialect._compiler_cls(shorten_names=(to == TPTPDialect._identifier() and shorten_names),
+                                            keep_annotations=not no_annotations)
     #if the parameter save is specified, the translation gets saved as a file with that name
     if save != "":
         with open(str(save), 'w') as file:

--- a/src/gavel/cli.py
+++ b/src/gavel/cli.py
@@ -18,6 +18,7 @@ Why does this file exist, and why not put this in __main__?
 import click
 import os
 import pkg_resources
+from gavel.dialects.tptp.dialect import TPTPDialect
 
 from gavel.dialects.tptp.parser import TPTPParser, TPTPProblemParser
 from gavel.prover.hets.interface import HetsProve, HetsSession, HetsEngine
@@ -68,9 +69,10 @@ def prove(p, f, s, plot, hets):
 @click.argument("frm")
 @click.argument("to")
 @click.argument("path")
-@click.option("--save", metavar="SAVE_PATH", default="", help="If set, saves the translation to SAVE_PATH")
+@click.option("--save", "-s", metavar="SAVE_PATH", default="", help="If set, saves the translation to SAVE_PATH")
+@click.option("--shorten-names", "-n", is_flag=True, help="Shorten names in output language (only for TPTP)")
 @click.pass_context
-def translate(ctx, frm, to, path, save):
+def translate(ctx, frm, to, path, save, shorten_names):
     """
     Translates the file at PATH from the dialect specified by FRM to the dialect TO. You can get a list of all available dialects via the `dialects` command.
 
@@ -85,7 +87,7 @@ def translate(ctx, frm, to, path, save):
     output_dialect = get_dialect(to)
 
     parser = input_dialect._parser_cls()
-    compiler = output_dialect._compiler_cls()
+    compiler = output_dialect._compiler_cls(shorten_names=(to == TPTPDialect._identifier() and shorten_names))
     #if the parameter save is specified, the translation gets saved as a file with that name
     if save != "":
         with open(str(save) + '.txt', 'w') as file:

--- a/src/gavel/cli.py
+++ b/src/gavel/cli.py
@@ -82,7 +82,7 @@ def translate(ctx, frm, to, path, save, shorten_names):
 
         This will parse a given TPTP-file into gavels internal logic and save a new equivalent TPTP theory in my-output.txt.
     """
-    kwargs= {ctx.args[i].strip('-'): ctx.args[i+1] for i in range(0, len(ctx.args), 2)}
+    kwargs = {ctx.args[i].strip('-'): ctx.args[i+1] for i in range(0, len(ctx.args), 2)}
     input_dialect = get_dialect(frm)
     output_dialect = get_dialect(to)
 

--- a/src/gavel/cli.py
+++ b/src/gavel/cli.py
@@ -78,11 +78,26 @@ def translate(ctx, frm, to, path, save, shorten_names):
 
     Example usage:
 
-        python -m gavel translate --save=my-output tptp tptp my-input-file.tptp
+        python -m gavel translate --save=my-output.p tptp tptp my-input-file.tptp
 
         This will parse a given TPTP-file into gavels internal logic and save a new equivalent TPTP theory in my-output.txt.
     """
-    kwargs = {ctx.args[i].strip('-'): ctx.args[i+1] for i in range(0, len(ctx.args), 2)}
+    # allow for arguments with variable number of values
+    index = 0
+    kwargs = {}
+    while index < len(ctx.args):
+        if (ctx.args[index].startswith('-')):
+            command = ctx.args[index].strip('-')
+            values = []
+            index += 1
+            while index < len(ctx.args) and not ctx.args[index].startswith('-'):
+                values.append(ctx.args[index])
+                index += 1
+
+            kwargs[command] = values
+        else:
+            index += 1
+
     input_dialect = get_dialect(frm)
     output_dialect = get_dialect(to)
 
@@ -90,7 +105,7 @@ def translate(ctx, frm, to, path, save, shorten_names):
     compiler = output_dialect._compiler_cls(shorten_names=(to == TPTPDialect._identifier() and shorten_names))
     #if the parameter save is specified, the translation gets saved as a file with that name
     if save != "":
-        with open(str(save) + '.txt', 'w') as file:
+        with open(str(save), 'w') as file:
             file.write(compiler.visit(parser.parse_from_file(path, **kwargs)))
     else:
         print(compiler.visit(parser.parse_from_file(path, **kwargs)))

--- a/src/gavel/cli.py
+++ b/src/gavel/cli.py
@@ -115,6 +115,7 @@ def translate(ctx, frm, to, path, save, shorten_names, no_annotations):
         print(translation)
 
     if frm == "annotated-owl" and to == TPTPDialect._identifier() and "save-dol" in kwargs:
+        ontology_text = parser.ontology_text_dol
         parser_mapping = parser.name_mapping
         compiler_mapping = compiler.name_mapping
 
@@ -122,9 +123,10 @@ def translate(ctx, frm, to, path, save, shorten_names, no_annotations):
                    f'ontology OWL_ontology = \n' \
             # f'\t<{parser.ontology_iri}>\n' \
 
-        with open(path, 'r') as file:
-            for line in file.readlines():
-                dol_text += f'\t\t{line}'
+        dol_text += ontology_text
+        #with open(path, 'r') as file:
+        #    for line in file.readlines():
+        #        dol_text += f'\t\t{line}'
 
         dol_text += f'\n\nend\n' \
                     f'\n' \
@@ -133,7 +135,7 @@ def translate(ctx, frm, to, path, save, shorten_names, no_annotations):
         for i, key in enumerate(parser_mapping):
             dol_text += '\t\t'
             if key in compiler_mapping:
-                dol_text += f'\'{parser_mapping[key]}\' |-> \'{compiler_mapping[key]}\''
+                dol_text += f'{parser_mapping[key]} |-> {compiler_mapping[key]}'
             else:
                 dol_text += f'{parser_mapping[key]} |-> {key}'
 

--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -6,8 +6,9 @@ import re
 
 class TPTPCompiler(Compiler):
 
-    def __init__(self, shorten_names=False):
+    def __init__(self, shorten_names=False, keep_annotations=True):
         self.shorten_names = shorten_names
+        self.keep_annotations = keep_annotations
 
     def visit_defined_constant(self, obj: fol.DefinedConstant):
         return self.visit(obj.value)
@@ -165,7 +166,7 @@ class TPTPCompiler(Compiler):
         )
 
     def visit_annotated_formula(self, anno: problem.AnnotatedFormula):
-        if (anno.annotation is None):
+        if anno.annotation is None or not self.keep_annotations:
             return "{}({},{},({})).".format(
                 anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula)
             )

--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -188,15 +188,15 @@ class TPTPCompiler(Compiler):
 
     def visit_functor_expression(self, expression: fol.FunctorExpression):
         return "{}({})".format(
-            self.visit(re.sub("[^A-z_0-9]", "_", expression.functor[:1].lower()
-                                                 + expression.functor[1:] if expression.functor else "")),
+            "'" + re.sub("[^A-z_0-9]", "_", expression.functor[:1].lower()
+                                                 + expression.functor[1:] if expression.functor else "") + "'",
             ",".join(map(self.visit, expression.arguments)),
         )
 
     def visit_predicate_expression(self, expression: fol.PredicateExpression):
         return "{}({})".format(
-            self.visit(re.sub("[^A-z_0-9]", "_", expression.predicate[:1].lower()
-                                                 + expression.predicate[1:] if expression.predicate else "")),
+            "'" + re.sub("[^A-z_0-9]", "_", expression.predicate[:1].lower()
+                                                 + expression.predicate[1:] if expression.predicate else "") + "'",
             ",".join(map(self.visit, expression.arguments)),
         )
 
@@ -243,8 +243,8 @@ class TPTPCompiler(Compiler):
         return "\"" + variable.symbol + "\""
 
     def visit_constant(self, variable: fol.Variable):
-        return re.sub("[^A-z_0-9]", "_", variable.symbol[:1].lower()
-                                                 + variable.symbol[1:] if variable.symbol else "")
+        return "'" + re.sub("[^A-z_0-9]", "_", variable.symbol[:1].lower()
+                                                 + variable.symbol[1:] if variable.symbol else "") + "'"
 
     def visit_problem(self, problem: problem.Problem):
         L = [self.visit(i) for i in problem.imports] + [self.visit(axiom) for axiom in problem.premises] + [self.visit(c) for c in problem.conjectures]

--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -284,7 +284,7 @@ class TPTPCompiler(Compiler):
             hashtag_pos = name[:-3].rfind("#")
             if slash_pos > 0:
                 cut_position = slash_pos + 1
-            if hashtag_pos < slash_pos:
+            if hashtag_pos > slash_pos:
                 cut_position = hashtag_pos + 1
 
         return name[cut_position:]

--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -161,6 +161,10 @@ class TPTPCompiler(Compiler):
         )
 
     def visit_annotated_formula(self, anno: problem.AnnotatedFormula):
+        if (anno.annotation is None):
+            return "{}({},{},({})).".format(
+                anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula)
+            )
         return "% {}\n{}({},{},({})).".format(
             anno.annotation.replace("\n", "\n% "), anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula)
         )

--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -161,8 +161,8 @@ class TPTPCompiler(Compiler):
         )
 
     def visit_annotated_formula(self, anno: problem.AnnotatedFormula):
-        return "{}({},{},({})).".format(
-            anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula)
+        return "% {}\n{}({},{},({})).".format(
+            anno.annotation, anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula)
         )
 
     def visit_binary_formula(self, formula: fol.BinaryFormula, parent_operand=None):

--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -162,7 +162,7 @@ class TPTPCompiler(Compiler):
 
     def visit_annotated_formula(self, anno: problem.AnnotatedFormula):
         return "% {}\n{}({},{},({})).".format(
-            anno.annotation, anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula)
+            anno.annotation.replace("\n", "\n% "), anno.logic, anno.name, self.visit(anno.role), self.visit(anno.formula)
         )
 
     def visit_binary_formula(self, formula: fol.BinaryFormula, parent_operand=None):

--- a/src/gavel/dialects/tptp/parser.py
+++ b/src/gavel/dialects/tptp/parser.py
@@ -334,6 +334,7 @@ def do(string):
     except Exception as e:
         raise Exception(str(e))
 
+
 class TPTPParser(LogicParser, StringBasedParser):
     def __init__(self):
         sys.setrecursionlimit(100000)
@@ -371,7 +372,6 @@ class TPTPParser(LogicParser, StringBasedParser):
                             quoted = x
                 buff += x
         yield buff
-
 
     def parse(self, structure: str, *args, **kwargs) -> Target:
         inputs = self.stream_lines(structure)

--- a/src/gavel/prover/eprover/interface.py
+++ b/src/gavel/prover/eprover/interface.py
@@ -22,7 +22,8 @@ class EProverInterface(BaseProverInterface):
 
     def _bootstrap_problem(self, problem: Problem):
         problem_string = "\n".join(self.dialect.compile(l) for l in problem.premises)
-        problem_string += self.dialect.compile(problem.conjectures)
+        for conjecture in problem.conjectures:
+            problem_string += self.dialect.compile(conjecture)
         return problem_string
 
     def _submit_problem(self, problem_instance, *args, **kwargs):

--- a/src/gavel/prover/eprover/interface.py
+++ b/src/gavel/prover/eprover/interface.py
@@ -1,7 +1,6 @@
 from gavel.prover.registry import register_prover
 from gavel.dialects.base.dialect import Problem
 from gavel.dialects.tptp.dialect import TPTPProofDialect
-from gavel.dialects.tptp.parser import SimpleTPTPProofParser
 from gavel.prover.base.interface import BaseProverInterface
 from gavel.prover.base.interface import BaseResultHandler
 import subprocess as sub
@@ -23,7 +22,7 @@ class EProverInterface(BaseProverInterface):
 
     def _bootstrap_problem(self, problem: Problem):
         problem_string = "\n".join(self.dialect.compile(l) for l in problem.premises)
-        problem_string += self.dialect.compile(problem.conjecture)
+        problem_string += self.dialect.compile(problem.conjectures)
         return problem_string
 
     def _submit_problem(self, problem_instance, *args, **kwargs):

--- a/tests/test_dialects/test_tptp/test_compiler.py
+++ b/tests/test_dialects/test_tptp/test_compiler.py
@@ -1,8 +1,8 @@
 import unittest
 
-from gavel.dialects.tptp.compiler import TPTPCompiler
 from gavel.logic import logic
 
+from src.gavel.dialects.tptp.compiler import TPTPCompiler
 from ..test_base.test_compiler import TestCompiler
 
 
@@ -24,3 +24,16 @@ class TestTPTPCompiler(TestCompiler):
                     ),
                     "X%sY" % expected_conn,
                 )
+
+    def test_predicate_names_starting_with_digits(self):
+        self.assert_compiler(
+            logic.PredicateExpression("123/test", [logic.Variable("X"), logic.Variable("Y")]),
+            "'123_test(X,Y)'",
+        )
+
+    def test_constant_names_starting_with_underscores(self):
+        self.assert_compiler(
+            logic.PredicateExpression("http___example_org_hasAncestor", [logic.Constant("http___example_org_Mary"), logic.Constant("__genid2147483649")]),
+            "'http___example_org_hasAncestor'('http___example_org_Mary','__genid2147483649')",
+        )
+

--- a/tests/test_dialects/test_tptp/test_compiler.py
+++ b/tests/test_dialects/test_tptp/test_compiler.py
@@ -44,3 +44,9 @@ class TestTPTPCompiler(TestCompiler):
             "% Annotation\nfof(test_axiom,axiom,('pred'('c')))."
         )
 
+    def test_annotated_formulas_no_annotation(self):
+        self.assert_compiler(
+            problem.AnnotatedFormula('fof', 'test_axiom', problem.FormulaRole.AXIOM, logic.PredicateExpression("pred", [logic.Constant('c')])),
+            "fof(test_axiom,axiom,('pred'('c')))."
+        )
+

--- a/tests/test_dialects/test_tptp/test_compiler.py
+++ b/tests/test_dialects/test_tptp/test_compiler.py
@@ -1,6 +1,7 @@
 import unittest
 
 from gavel.logic import logic
+from gavel.logic import problem
 
 from src.gavel.dialects.tptp.compiler import TPTPCompiler
 from ..test_base.test_compiler import TestCompiler
@@ -28,12 +29,18 @@ class TestTPTPCompiler(TestCompiler):
     def test_predicate_names_starting_with_digits(self):
         self.assert_compiler(
             logic.PredicateExpression("123/test", [logic.Variable("X"), logic.Variable("Y")]),
-            "'123_test(X,Y)'",
+            "'123_test'(X,Y)",
         )
 
     def test_constant_names_starting_with_underscores(self):
         self.assert_compiler(
             logic.PredicateExpression("http___example_org_hasAncestor", [logic.Constant("http___example_org_Mary"), logic.Constant("__genid2147483649")]),
             "'http___example_org_hasAncestor'('http___example_org_Mary','__genid2147483649')",
+        )
+
+    def test_annotated_formulas(self):
+        self.assert_compiler(
+            problem.AnnotatedFormula('fof', 'test_axiom', problem.FormulaRole.AXIOM, logic.PredicateExpression("pred", [logic.Constant('c')]), "Annotation"),
+            "% Annotation\nfof(test_axiom,axiom,('pred'('c')))."
         )
 


### PR DESCRIPTION
Around predicates, functors, and constants, I added single quotes.
This solves #14 and some similar problems I had with underscores (OWL anonymous individuals translate to something like __genid2147483649).

Also, I added comment lines above each axiom which contain the axioms annotation. This solves #5 .

Other changes: support for DOL files (for annotated-owl), new context argument system, some new options and bugfixes.

closes #14 closes #5 