### PR TITLE
Vampire prover args / output handling

### DIFF
--- a/src/gavel/prover/base/interface.py
+++ b/src/gavel/prover/base/interface.py
@@ -15,17 +15,16 @@ class BaseProverInterface:
     _prover_dialect_cls = IdentityDialect
     """
     A dialect class that is instantiated and used to compile to
-    and parse from a format suppported by the prover
+    and parse from a format supported by the prover
     """
 
     def __init__(self, *args, **kwargs):
-        super(BaseProverInterface, self).__init__(*args, **kwargs)
         self.flags = []
         self.dialect = self._prover_dialect_cls()
 
     def prove(self, problem: Problem, *args, **kwargs) -> Proof:
         """
-        Takes a instance of a gavel proof problem.
+        Takes an instance of a gavel proof problem.
         submits it to the prover in a supported format and parses the result
         into a gavel proof object. Both translations are handled by the prover
         dialect in :class:`_prover_dialect_cls`
@@ -85,7 +84,7 @@ class BaseProverInterface:
 
     def _post_process_proof(self, raw_proof_result):
         """
-        Apply some transformation to make the output of the prover processabe
+        Apply some transformation to make the output of the prover processable
         by `_prover_dialect_cls`
 
         Parameters

--- a/src/gavel/prover/vampire/interface.py
+++ b/src/gavel/prover/vampire/interface.py
@@ -18,7 +18,7 @@ class VampireInterface(BaseProverInterface):
         super().__init__(*args, **kwargs)
         flags = kwargs.get("flags", [])
         if not flags:
-            flags = ["-p tptp", "-t 300"]
+            flags = ["-p tptp", "--input_syntax tptp", "-t 300"]
         self.flags = flags
 
     def _bootstrap_problem(self, problem: Problem):
@@ -48,7 +48,10 @@ class VampireInterface(BaseProverInterface):
                         tf.name,
                     ]), shell=True).decode("utf-8")
             except sub.CalledProcessError as e:
-                raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
+                if not re.search(r"SZS status (\w+)", e):
+                    raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
+                result = e
+
         return result
 
     def _post_process_proof(self, raw_proof_result):

--- a/src/gavel/prover/vampire/interface.py
+++ b/src/gavel/prover/vampire/interface.py
@@ -48,9 +48,9 @@ class VampireInterface(BaseProverInterface):
                         tf.name,
                     ]), shell=True).decode("utf-8")
             except sub.CalledProcessError as e:
-                if not re.search(r"SZS status (\w+)", e):
+                if not re.search(r"SZS status (\w+)", e.output.decode("utf-8")):
                     raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
-                result = e
+                result = e.output.decode("utf-8")
 
         return result
 


### PR DESCRIPTION
- fixes setting of vampire flags via argument
- does not raise an Exception if the error message contains an SZS status (based on the assumption that Vampire sometimes outputs proofs with exit status != 0