### PR TITLE
Feature/chemlog intergration

### DIFF
--- a/src/gavel/logic/logic.py
+++ b/src/gavel/logic/logic.py
@@ -415,7 +415,8 @@ class BinaryFormula(LogicExpression):
 
     requires_parens = True
 
-    def __init__(self, left: LogicExpression, operator: BinaryConnective, right: LogicExpression):
+    def __init__(self, left: LogicExpression | TermExpression, operator: BinaryConnective,
+                 right: LogicExpression | TermExpression):
         self.left = left
         self.right = right
         self.operator = operator
@@ -430,7 +431,7 @@ class BinaryFormula(LogicExpression):
             return self.left == other.left and self.right == other.right
         else:
             return (self.left == other.left and self.right == other.right) or (
-                        self.left == other.right and self.right == other.left)
+                    self.left == other.right and self.right == other.left)
 
     def symbols(self):
         return chain(self.left.symbols(), self.right.symbols())

--- a/src/gavel/logic/logic.py
+++ b/src/gavel/logic/logic.py
@@ -503,7 +503,8 @@ class PredicateExpression(LogicExpression):
         return "%s(%s)" % (self.predicate, ", ".join(map(str, self.arguments)))
 
     def __eq__(self, other):
-        return (type(self) is type(other) and self.predicate == other.predicate
+        return (isinstance(other, PredicateExpression)
+                and self.predicate == other.predicate
                 and len(self.arguments) == len(other.arguments)
                 and all(arg1 == arg2 for arg1, arg2 in zip(self.arguments, other.arguments)))
 

--- a/src/gavel/logic/logic_utils.py
+++ b/src/gavel/logic/logic_utils.py
@@ -1,0 +1,227 @@
+import itertools
+import logging
+from queue import Queue
+from typing import Optional, Set
+
+import gavel.logic.logic as logic
+
+
+# basic functionality for manipulating FOL formulas
+
+def binary_to_nary(formula: logic.LogicExpression, connective: logic.BinaryConnective) -> logic.NaryFormula:
+    assert connective.is_associative()
+    if isinstance(formula, logic.BinaryFormula) and formula.operator == connective:
+        return (logic.NaryFormula(connective, binary_to_nary(formula.left, connective).formulae
+                            + binary_to_nary(formula.right, connective).formulae))
+    if isinstance(formula, logic.NaryFormula) and formula.operator == connective:
+        return (logic.NaryFormula(connective, [f for sub in formula.formulae
+                                         for f in binary_to_nary(sub, connective).formulae]))
+    else:
+        return logic.NaryFormula(connective, [formula])
+
+
+def get_vars_in_formula(formula: logic.LogicElement) -> Set[logic.Variable]:
+    if isinstance(formula, logic.Variable):
+        return {formula}
+    elif isinstance(formula, logic.PredicateExpression):
+        return set(arg for arg in formula.arguments if isinstance(arg, logic.Variable))
+    elif isinstance(formula, logic.BinaryFormula):
+        return get_vars_in_formula(formula.left).union(get_vars_in_formula(formula.right))
+    elif isinstance(formula, logic.UnaryFormula) or isinstance(formula, logic.QuantifiedFormula):
+        return get_vars_in_formula(formula.formula)
+    elif isinstance(formula, logic.NaryFormula) and len(formula.formulae) > 0:
+        try:
+            return set.union(*[get_vars_in_formula(f) for f in formula.formulae])
+        except TypeError as e:
+            return set()
+    else:
+        return set()
+
+
+def substitute_var_in_formula(formula: logic.LogicElement, var: Optional[logic.Variable], ind):
+    """Replace every occurrence of variable var with ind. If var is None, replace all variables with ind"""
+    if isinstance(formula, logic.NaryFormula):
+        return logic.NaryFormula(formula.operator, [substitute_var_in_formula(f, var, ind) for f in formula.formulae])
+    elif isinstance(formula, logic.PredicateExpression):
+        return logic.PredicateExpression(formula.predicate,
+                                         [ind if isinstance(arg, logic.Variable) and (not var or arg == var)
+                                          else arg for arg in formula.arguments])
+    elif isinstance(formula, logic.UnaryFormula):
+        return logic.UnaryFormula(formula.connective, substitute_var_in_formula(formula.formula, var, ind))
+    elif isinstance(formula, logic.QuantifiedFormula):
+        variables = [arg for arg in formula.variables if arg != var]
+        return logic.QuantifiedFormula(formula.quantifier, variables,
+                                       substitute_var_in_formula(formula.formula, var, ind))
+    elif isinstance(formula, logic.BinaryFormula):
+        left = substitute_var_in_formula(formula.left, var, ind)
+        right = substitute_var_in_formula(formula.right, var, ind)
+        return logic.BinaryFormula(left, formula.operator, right)
+    elif isinstance(formula, logic.Variable):
+        return ind if not var or formula == var else formula
+    return formula
+
+
+def replace_predicate_symbol(formula: logic.LogicElement, old: str, new: str):
+    """Replace every occurrence of a predicate symbol in a given formula"""
+    if isinstance(formula, logic.PredicateExpression) and formula.predicate == old:
+        formula.predicate = new
+    elif isinstance(formula, logic.UnaryFormula):
+        formula.formula = replace_predicate_symbol(formula.formula, old, new)
+    elif isinstance(formula, logic.QuantifiedFormula):
+        formula.formula = replace_predicate_symbol(formula.formula, old, new)
+    elif isinstance(formula, logic.BinaryFormula):
+        formula.left = replace_predicate_symbol(formula.left, old, new)
+        formula.right = replace_predicate_symbol(formula.right, old, new)
+    elif isinstance(formula, logic.NaryFormula):
+        formula.formulae = [replace_predicate_symbol(f, old, new) for f in formula.formulae]
+    return formula
+
+
+def is_atom_formula(formula: logic.LogicExpression):
+    if not isinstance(formula, logic.PredicateExpression):
+        return False
+    # allow integers as terms
+    return (isinstance(formula.arguments, logic.TermExpression)
+            or all(isinstance(t, logic.TermExpression) or isinstance(t, int) for t in formula.arguments))
+
+
+def is_literal(formula: logic.LogicExpression):
+    return (is_atom_formula(formula) or (isinstance(formula, logic.UnaryFormula) and is_atom_formula(formula.formula))
+            or (isinstance(formula, logic.BinaryFormula)
+                and (formula.operator == logic.BinaryConnective.EQ or formula.operator == logic.BinaryConnective.NEQ)))
+
+
+def convert_biimplication_to_cnf(formula: logic.BinaryFormula):
+    """a <-> b <=> (~a | b) & (~b | a)"""
+    assert formula.operator == logic.BinaryConnective.BIIMPLICATION
+    return logic.BinaryFormula(
+        logic.BinaryFormula(
+            logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula.left),
+            logic.BinaryConnective.DISJUNCTION,
+            formula.right
+        ),
+        logic.BinaryConnective.CONJUNCTION,
+        logic.BinaryFormula(
+            formula.left,
+            logic.BinaryConnective.DISJUNCTION,
+            logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula.right),
+        ),
+    )
+
+
+def convert_implication_to_disjunction(formula: logic.BinaryFormula):
+    """a -> b <=> ~a | b"""
+    assert formula.operator == logic.BinaryConnective.IMPLICATION
+    return logic.BinaryFormula(
+        logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula.left),
+        logic.BinaryConnective.DISJUNCTION,
+        formula.right
+    )
+
+
+def convert_to_nnf(formula: logic.LogicExpression):
+    """Replace all <-> with (~a|b)&(~b|a), all -> with (~a|b), all ~(a!=b) with a=b, all ~(a=b) with a!=b,
+    all ~(a|b) with (~a&~b), all ~(a&b) with (~a|~b), all ~![] with ?[]~, all ~?[] with ?[]~, all ~~a with a.
+    Resulting formula will only have |, & and ~ operations and ~ only for literals"""
+    if isinstance(formula, logic.UnaryFormula) and formula.connective == logic.UnaryConnective.NEGATION:
+        if isinstance(formula.formula, logic.QuantifiedFormula):
+            if formula.formula.quantifier == logic.Quantifier.EXISTENTIAL:
+                quantifier = logic.Quantifier.UNIVERSAL
+            else:
+                quantifier = logic.Quantifier.EXISTENTIAL
+            return logic.QuantifiedFormula(
+                quantifier, formula.formula.variables,
+                convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula.formula.formula)))
+        elif isinstance(formula.formula,
+                        logic.BinaryFormula) and formula.formula.operator == logic.BinaryConnective.BIIMPLICATION:
+            return convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION,
+                                                     convert_biimplication_to_cnf(formula.formula)))
+        elif isinstance(formula.formula,
+                        logic.BinaryFormula) and formula.formula.operator == logic.BinaryConnective.IMPLICATION:
+            return convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION,
+                                                     convert_implication_to_disjunction(formula.formula)))
+        elif isinstance(formula.formula, logic.BinaryFormula) or isinstance(formula.formula, logic.NaryFormula):
+            if formula.formula.operator == logic.BinaryConnective.DISJUNCTION:
+                operator = logic.BinaryConnective.CONJUNCTION
+            elif formula.formula.operator == logic.BinaryConnective.CONJUNCTION:
+                operator = logic.BinaryConnective.DISJUNCTION
+            elif formula.formula.operator == logic.BinaryConnective.EQ:
+                assert isinstance(formula.formula, logic.BinaryFormula)
+                return logic.BinaryFormula(formula.formula.left, logic.BinaryConnective.NEQ, formula.formula.right)
+            elif formula.formula.operator == logic.BinaryConnective.NEQ:
+                assert isinstance(formula.formula, logic.BinaryFormula)
+                return logic.BinaryFormula(formula.formula.left, logic.BinaryConnective.EQ, formula.formula.right)
+            else:
+                raise NotImplementedError
+            if isinstance(formula.formula, logic.BinaryFormula):
+                return logic.BinaryFormula(
+                    convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula.formula.left)),
+                    operator,
+                    convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula.formula.right)),
+                )
+            else:
+                return logic.NaryFormula(operator, [convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION, f))
+                                              for f in formula.formula.formulae])
+        elif isinstance(formula.formula,
+                        logic.UnaryFormula) and formula.formula.connective == logic.UnaryConnective.NEGATION:
+            return convert_to_nnf(formula.formula.formula)
+        else:
+            return formula
+    else:
+        if isinstance(formula, logic.QuantifiedFormula):
+            return logic.QuantifiedFormula(formula.quantifier, formula.variables, convert_to_nnf(formula.formula))
+        elif isinstance(formula, logic.BinaryFormula) and formula.operator == logic.BinaryConnective.BIIMPLICATION:
+            return convert_to_nnf(convert_biimplication_to_cnf(formula))
+        elif isinstance(formula, logic.BinaryFormula) and formula.operator == logic.BinaryConnective.IMPLICATION:
+            return convert_to_nnf(convert_implication_to_disjunction(formula))
+        elif isinstance(formula, logic.BinaryFormula):
+            return logic.BinaryFormula(
+                convert_to_nnf(formula.left),
+                formula.operator,
+                convert_to_nnf(formula.right),
+            )
+        elif isinstance(formula, logic.NaryFormula):
+            return logic.NaryFormula(formula.operator, [convert_to_nnf(f) for f in formula.formulae])
+        else:
+            return formula
+
+
+def convert_to_cnf(formula: logic.LogicExpression) -> logic.NaryFormula:
+    """Assumes no quantifiers"""
+    formula = convert_to_nnf(formula)
+    clauses = []
+    unprocessed_clauses = Queue()
+    unprocessed_clauses.put(formula)
+
+    while not unprocessed_clauses.empty():
+        clause = unprocessed_clauses.get()
+        if isinstance(clause, logic.NaryFormula) or isinstance(clause, logic.BinaryFormula):
+            # nested conjunctions: resolve
+            if clause.operator == logic.BinaryConnective.CONJUNCTION:
+                if isinstance(clause, logic.BinaryFormula):
+                    unprocessed_clauses.put(formula.left)
+                    unprocessed_clauses.put(formula.right)
+                else:
+                    assert isinstance(clause, logic.NaryFormula)
+                    for f in clause.formulae:
+                        unprocessed_clauses.put(f)
+            # disjunctions: apply cnf recursively, then distribute
+            # i.e. [(A|B)&(C|D)] | [(E|F)&(G|H)] -> (A|B|E|F)&(A|B|G|H)&(C|D|E|F)&(C|D|G|H)
+            elif clause.operator == logic.BinaryConnective.DISJUNCTION:
+                if isinstance(clause, logic.BinaryFormula):
+                    disj_parts = [clause.left, clause.right]
+                else:
+                    assert isinstance(clause, logic.NaryFormula)
+                    disj_parts = clause.formulae
+                disj_parts = [convert_to_cnf(p).formulae for p in disj_parts]
+                for combination in itertools.product(*disj_parts):
+                    clause_elements = []
+                    for c in combination:
+                        clause_elements += c.formulae
+                    clauses.append(logic.NaryFormula(logic.BinaryConnective.DISJUNCTION, clause_elements))
+            else:
+                clauses.append(logic.NaryFormula(logic.BinaryConnective.DISJUNCTION, [clause]))
+        else:
+            clauses.append(logic.NaryFormula(logic.BinaryConnective.DISJUNCTION, [clause]))
+
+    return logic.NaryFormula(logic.BinaryConnective.CONJUNCTION, clauses)

--- a/src/gavel/logic/logic_utils.py
+++ b/src/gavel/logic/logic_utils.py
@@ -1,5 +1,4 @@
 import itertools
-import logging
 from queue import Queue
 from typing import Optional, Set
 
@@ -8,14 +7,28 @@ import gavel.logic.logic as logic
 
 # basic functionality for manipulating FOL formulas
 
-def binary_to_nary(formula: logic.LogicExpression, connective: logic.BinaryConnective) -> logic.NaryFormula:
+
+def binary_to_nary(
+    formula: logic.LogicExpression, connective: logic.BinaryConnective
+) -> logic.NaryFormula:
     assert connective.is_associative()
     if isinstance(formula, logic.BinaryFormula) and formula.operator == connective:
-        return (logic.NaryFormula(connective, binary_to_nary(formula.left, connective).formulae
-                            + binary_to_nary(formula.right, connective).formulae))
+        return logic.NaryFormula(
+            connective,
+            itertools.chain(
+                binary_to_nary(formula.left, connective).formulae,
+                binary_to_nary(formula.right, connective).formulae,
+            ),
+        )
     if isinstance(formula, logic.NaryFormula) and formula.operator == connective:
-        return (logic.NaryFormula(connective, [f for sub in formula.formulae
-                                         for f in binary_to_nary(sub, connective).formulae]))
+        return logic.NaryFormula(
+            connective,
+            [
+                f
+                for sub in formula.formulae
+                for f in binary_to_nary(sub, connective).formulae
+            ],
+        )
     else:
         return logic.NaryFormula(connective, [formula])
 
@@ -26,32 +39,56 @@ def get_vars_in_formula(formula: logic.LogicElement) -> Set[logic.Variable]:
     elif isinstance(formula, logic.PredicateExpression):
         return set(arg for arg in formula.arguments if isinstance(arg, logic.Variable))
     elif isinstance(formula, logic.BinaryFormula):
-        return get_vars_in_formula(formula.left).union(get_vars_in_formula(formula.right))
-    elif isinstance(formula, logic.UnaryFormula) or isinstance(formula, logic.QuantifiedFormula):
+        return get_vars_in_formula(formula.left).union(
+            get_vars_in_formula(formula.right)
+        )
+    elif isinstance(formula, logic.UnaryFormula) or isinstance(
+        formula, logic.QuantifiedFormula
+    ):
         return get_vars_in_formula(formula.formula)
-    elif isinstance(formula, logic.NaryFormula) and len(formula.formulae) > 0:
-        try:
-            return set.union(*[get_vars_in_formula(f) for f in formula.formulae])
-        except TypeError as e:
-            return set()
+    elif isinstance(formula, logic.NaryFormula):
+        variables = [get_vars_in_formula(f) for f in formula.formulae]
+        if len(variables) > 0:
+            try:
+                return set.union(*variables)
+            except TypeError:
+                return set()
     else:
         return set()
 
 
-def substitute_var_in_formula(formula: logic.LogicElement, var: Optional[logic.Variable], ind):
+def substitute_var_in_formula(
+    formula: logic.LogicElement, var: Optional[logic.Variable], ind
+):
     """Replace every occurrence of variable var with ind. If var is None, replace all variables with ind"""
     if isinstance(formula, logic.NaryFormula):
-        return logic.NaryFormula(formula.operator, [substitute_var_in_formula(f, var, ind) for f in formula.formulae])
+        return logic.NaryFormula(
+            formula.operator,
+            [substitute_var_in_formula(f, var, ind) for f in formula.formulae],
+        )
     elif isinstance(formula, logic.PredicateExpression):
-        return logic.PredicateExpression(formula.predicate,
-                                         [ind if isinstance(arg, logic.Variable) and (not var or arg == var)
-                                          else arg for arg in formula.arguments])
+        return logic.PredicateExpression(
+            formula.predicate,
+            [
+                (
+                    ind
+                    if isinstance(arg, logic.Variable) and (not var or arg == var)
+                    else arg
+                )
+                for arg in formula.arguments
+            ],
+        )
     elif isinstance(formula, logic.UnaryFormula):
-        return logic.UnaryFormula(formula.connective, substitute_var_in_formula(formula.formula, var, ind))
+        return logic.UnaryFormula(
+            formula.connective, substitute_var_in_formula(formula.formula, var, ind)
+        )
     elif isinstance(formula, logic.QuantifiedFormula):
         variables = [arg for arg in formula.variables if arg != var]
-        return logic.QuantifiedFormula(formula.quantifier, variables,
-                                       substitute_var_in_formula(formula.formula, var, ind))
+        return logic.QuantifiedFormula(
+            formula.quantifier,
+            variables,
+            substitute_var_in_formula(formula.formula, var, ind),
+        )
     elif isinstance(formula, logic.BinaryFormula):
         left = substitute_var_in_formula(formula.left, var, ind)
         right = substitute_var_in_formula(formula.right, var, ind)
@@ -73,7 +110,9 @@ def replace_predicate_symbol(formula: logic.LogicElement, old: str, new: str):
         formula.left = replace_predicate_symbol(formula.left, old, new)
         formula.right = replace_predicate_symbol(formula.right, old, new)
     elif isinstance(formula, logic.NaryFormula):
-        formula.formulae = [replace_predicate_symbol(f, old, new) for f in formula.formulae]
+        formula.formulae = [
+            replace_predicate_symbol(f, old, new) for f in formula.formulae
+        ]
     return formula
 
 
@@ -81,14 +120,26 @@ def is_atom_formula(formula: logic.LogicExpression):
     if not isinstance(formula, logic.PredicateExpression):
         return False
     # allow integers as terms
-    return (isinstance(formula.arguments, logic.TermExpression)
-            or all(isinstance(t, logic.TermExpression) or isinstance(t, int) for t in formula.arguments))
+    return isinstance(formula.arguments, logic.TermExpression) or all(
+        isinstance(t, logic.TermExpression) or isinstance(t, int)
+        for t in formula.arguments
+    )
 
 
 def is_literal(formula: logic.LogicExpression):
-    return (is_atom_formula(formula) or (isinstance(formula, logic.UnaryFormula) and is_atom_formula(formula.formula))
-            or (isinstance(formula, logic.BinaryFormula)
-                and (formula.operator == logic.BinaryConnective.EQ or formula.operator == logic.BinaryConnective.NEQ)))
+    return (
+        is_atom_formula(formula)
+        or (
+            isinstance(formula, logic.UnaryFormula) and is_atom_formula(formula.formula)
+        )
+        or (
+            isinstance(formula, logic.BinaryFormula)
+            and (
+                formula.operator == logic.BinaryConnective.EQ
+                or formula.operator == logic.BinaryConnective.NEQ
+            )
+        )
+    )
 
 
 def convert_biimplication_to_cnf(formula: logic.BinaryFormula):
@@ -98,7 +149,7 @@ def convert_biimplication_to_cnf(formula: logic.BinaryFormula):
         logic.BinaryFormula(
             logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula.left),
             logic.BinaryConnective.DISJUNCTION,
-            formula.right
+            formula.right,
         ),
         logic.BinaryConnective.CONJUNCTION,
         logic.BinaryFormula(
@@ -115,7 +166,7 @@ def convert_implication_to_disjunction(formula: logic.BinaryFormula):
     return logic.BinaryFormula(
         logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula.left),
         logic.BinaryConnective.DISJUNCTION,
-        formula.right
+        formula.right,
     )
 
 
@@ -123,56 +174,112 @@ def convert_to_nnf(formula: logic.LogicExpression):
     """Replace all <-> with (~a|b)&(~b|a), all -> with (~a|b), all ~(a!=b) with a=b, all ~(a=b) with a!=b,
     all ~(a|b) with (~a&~b), all ~(a&b) with (~a|~b), all ~![] with ?[]~, all ~?[] with ?[]~, all ~~a with a.
     Resulting formula will only have |, & and ~ operations and ~ only for literals"""
-    if isinstance(formula, logic.UnaryFormula) and formula.connective == logic.UnaryConnective.NEGATION:
+    if (
+        isinstance(formula, logic.UnaryFormula)
+        and formula.connective == logic.UnaryConnective.NEGATION
+    ):
         if isinstance(formula.formula, logic.QuantifiedFormula):
             if formula.formula.quantifier == logic.Quantifier.EXISTENTIAL:
                 quantifier = logic.Quantifier.UNIVERSAL
             else:
                 quantifier = logic.Quantifier.EXISTENTIAL
             return logic.QuantifiedFormula(
-                quantifier, formula.formula.variables,
-                convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula.formula.formula)))
-        elif isinstance(formula.formula,
-                        logic.BinaryFormula) and formula.formula.operator == logic.BinaryConnective.BIIMPLICATION:
-            return convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION,
-                                                     convert_biimplication_to_cnf(formula.formula)))
-        elif isinstance(formula.formula,
-                        logic.BinaryFormula) and formula.formula.operator == logic.BinaryConnective.IMPLICATION:
-            return convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION,
-                                                     convert_implication_to_disjunction(formula.formula)))
-        elif isinstance(formula.formula, logic.BinaryFormula) or isinstance(formula.formula, logic.NaryFormula):
+                quantifier,
+                formula.formula.variables,
+                convert_to_nnf(
+                    logic.UnaryFormula(
+                        logic.UnaryConnective.NEGATION, formula.formula.formula
+                    )
+                ),
+            )
+        elif (
+            isinstance(formula.formula, logic.BinaryFormula)
+            and formula.formula.operator == logic.BinaryConnective.BIIMPLICATION
+        ):
+            return convert_to_nnf(
+                logic.UnaryFormula(
+                    logic.UnaryConnective.NEGATION,
+                    convert_biimplication_to_cnf(formula.formula),
+                )
+            )
+        elif (
+            isinstance(formula.formula, logic.BinaryFormula)
+            and formula.formula.operator == logic.BinaryConnective.IMPLICATION
+        ):
+            return convert_to_nnf(
+                logic.UnaryFormula(
+                    logic.UnaryConnective.NEGATION,
+                    convert_implication_to_disjunction(formula.formula),
+                )
+            )
+        elif isinstance(formula.formula, logic.BinaryFormula) or isinstance(
+            formula.formula, logic.NaryFormula
+        ):
             if formula.formula.operator == logic.BinaryConnective.DISJUNCTION:
                 operator = logic.BinaryConnective.CONJUNCTION
             elif formula.formula.operator == logic.BinaryConnective.CONJUNCTION:
                 operator = logic.BinaryConnective.DISJUNCTION
             elif formula.formula.operator == logic.BinaryConnective.EQ:
                 assert isinstance(formula.formula, logic.BinaryFormula)
-                return logic.BinaryFormula(formula.formula.left, logic.BinaryConnective.NEQ, formula.formula.right)
+                return logic.BinaryFormula(
+                    formula.formula.left,
+                    logic.BinaryConnective.NEQ,
+                    formula.formula.right,
+                )
             elif formula.formula.operator == logic.BinaryConnective.NEQ:
                 assert isinstance(formula.formula, logic.BinaryFormula)
-                return logic.BinaryFormula(formula.formula.left, logic.BinaryConnective.EQ, formula.formula.right)
+                return logic.BinaryFormula(
+                    formula.formula.left,
+                    logic.BinaryConnective.EQ,
+                    formula.formula.right,
+                )
             else:
                 raise NotImplementedError
             if isinstance(formula.formula, logic.BinaryFormula):
                 return logic.BinaryFormula(
-                    convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula.formula.left)),
+                    convert_to_nnf(
+                        logic.UnaryFormula(
+                            logic.UnaryConnective.NEGATION, formula.formula.left
+                        )
+                    ),
                     operator,
-                    convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula.formula.right)),
+                    convert_to_nnf(
+                        logic.UnaryFormula(
+                            logic.UnaryConnective.NEGATION, formula.formula.right
+                        )
+                    ),
                 )
             else:
-                return logic.NaryFormula(operator, [convert_to_nnf(logic.UnaryFormula(logic.UnaryConnective.NEGATION, f))
-                                              for f in formula.formula.formulae])
-        elif isinstance(formula.formula,
-                        logic.UnaryFormula) and formula.formula.connective == logic.UnaryConnective.NEGATION:
+                return logic.NaryFormula(
+                    operator,
+                    [
+                        convert_to_nnf(
+                            logic.UnaryFormula(logic.UnaryConnective.NEGATION, f)
+                        )
+                        for f in formula.formula.formulae
+                    ],
+                )
+        elif (
+            isinstance(formula.formula, logic.UnaryFormula)
+            and formula.formula.connective == logic.UnaryConnective.NEGATION
+        ):
             return convert_to_nnf(formula.formula.formula)
         else:
             return formula
     else:
         if isinstance(formula, logic.QuantifiedFormula):
-            return logic.QuantifiedFormula(formula.quantifier, formula.variables, convert_to_nnf(formula.formula))
-        elif isinstance(formula, logic.BinaryFormula) and formula.operator == logic.BinaryConnective.BIIMPLICATION:
+            return logic.QuantifiedFormula(
+                formula.quantifier, formula.variables, convert_to_nnf(formula.formula)
+            )
+        elif (
+            isinstance(formula, logic.BinaryFormula)
+            and formula.operator == logic.BinaryConnective.BIIMPLICATION
+        ):
             return convert_to_nnf(convert_biimplication_to_cnf(formula))
-        elif isinstance(formula, logic.BinaryFormula) and formula.operator == logic.BinaryConnective.IMPLICATION:
+        elif (
+            isinstance(formula, logic.BinaryFormula)
+            and formula.operator == logic.BinaryConnective.IMPLICATION
+        ):
             return convert_to_nnf(convert_implication_to_disjunction(formula))
         elif isinstance(formula, logic.BinaryFormula):
             return logic.BinaryFormula(
@@ -181,7 +288,9 @@ def convert_to_nnf(formula: logic.LogicExpression):
                 convert_to_nnf(formula.right),
             )
         elif isinstance(formula, logic.NaryFormula):
-            return logic.NaryFormula(formula.operator, [convert_to_nnf(f) for f in formula.formulae])
+            return logic.NaryFormula(
+                formula.operator, [convert_to_nnf(f) for f in formula.formulae]
+            )
         else:
             return formula
 
@@ -195,7 +304,9 @@ def convert_to_cnf(formula: logic.LogicExpression) -> logic.NaryFormula:
 
     while not unprocessed_clauses.empty():
         clause = unprocessed_clauses.get()
-        if isinstance(clause, logic.NaryFormula) or isinstance(clause, logic.BinaryFormula):
+        if isinstance(clause, logic.NaryFormula) or isinstance(
+            clause, logic.BinaryFormula
+        ):
             # nested conjunctions: resolve
             if clause.operator == logic.BinaryConnective.CONJUNCTION:
                 if isinstance(clause, logic.BinaryFormula):
@@ -218,10 +329,18 @@ def convert_to_cnf(formula: logic.LogicExpression) -> logic.NaryFormula:
                     clause_elements = []
                     for c in combination:
                         clause_elements += c.formulae
-                    clauses.append(logic.NaryFormula(logic.BinaryConnective.DISJUNCTION, clause_elements))
+                    clauses.append(
+                        logic.NaryFormula(
+                            logic.BinaryConnective.DISJUNCTION, clause_elements
+                        )
+                    )
             else:
-                clauses.append(logic.NaryFormula(logic.BinaryConnective.DISJUNCTION, [clause]))
+                clauses.append(
+                    logic.NaryFormula(logic.BinaryConnective.DISJUNCTION, [clause])
+                )
         else:
-            clauses.append(logic.NaryFormula(logic.BinaryConnective.DISJUNCTION, [clause]))
+            clauses.append(
+                logic.NaryFormula(logic.BinaryConnective.DISJUNCTION, [clause])
+            )
 
     return logic.NaryFormula(logic.BinaryConnective.CONJUNCTION, clauses)

--- a/src/gavel/logic/logic_utils.py
+++ b/src/gavel/logic/logic_utils.py
@@ -15,10 +15,10 @@ def binary_to_nary(
     if isinstance(formula, logic.BinaryFormula) and formula.operator == connective:
         return logic.NaryFormula(
             connective,
-            itertools.chain(
+            list(itertools.chain(
                 binary_to_nary(formula.left, connective).formulae,
                 binary_to_nary(formula.right, connective).formulae,
-            ),
+            )),
         )
     if isinstance(formula, logic.NaryFormula) and formula.operator == connective:
         return logic.NaryFormula(
@@ -48,6 +48,7 @@ def get_vars_in_formula(formula: logic.LogicElement) -> Set[logic.Variable]:
         return get_vars_in_formula(formula.formula)
     elif isinstance(formula, logic.NaryFormula):
         variables = [get_vars_in_formula(f) for f in formula.formulae]
+        variables = [v for v in variables if v is not None]
         if len(variables) > 0:
             try:
                 return set.union(*variables)

--- a/tests/test_logic/test_logic.py
+++ b/tests/test_logic/test_logic.py
@@ -1,6 +1,7 @@
 import unittest
 from gavel.logic import logic
 
+
 class TestEquality(unittest.TestCase):
     """Syntactic equality (with symmetry) between gavel formulas"""
 

--- a/tests/test_logic/test_logic.py
+++ b/tests/test_logic/test_logic.py
@@ -1,0 +1,77 @@
+import unittest
+from gavel.logic import logic
+
+class TestEquality(unittest.TestCase):
+    """Syntactic equality (with symmetry) between gavel formulas"""
+
+    def test_predicate(self):
+        v1 = logic.Variable("v1")
+        v3 = logic.Constant("v3")
+        f1 = logic.PredicateExpression("abc", [v1, v3])
+        f2 = logic.PredicateExpression("abc", [v1, v3])
+        f3 = logic.PredicateExpression("abc", [v1, logic.Constant("v4")])
+        f4 = logic.PredicateExpression("abc", [v1])
+        f5 = logic.PredicateExpression("def", [v1, v3])
+        self.assertEqual(f1, f2)
+        self.assertNotEqual(f1, f3)
+        self.assertNotEqual(f1, f4)
+        self.assertNotEqual(f1, f5)
+
+    def test_symmetric_conj(self):
+        v1 = logic.Variable("v1")
+        v3 = logic.Constant("v3")
+        formulae = [logic.PredicateExpression("abc", [v1, v3]),
+                    logic.PredicateExpression("def", [v3, v1, v1]),
+                    logic.UnaryFormula(logic.UnaryConnective.NEGATION, logic.PredicateExpression("abc", [v1, v1]))]
+        f1 = logic.BinaryFormula(formulae[0], logic.BinaryConnective.CONJUNCTION, formulae[1])
+        f2 = logic.BinaryFormula(formulae[1], logic.BinaryConnective.CONJUNCTION, formulae[0])
+        f3 = logic.BinaryFormula(formulae[0], logic.BinaryConnective.DISJUNCTION, formulae[1])
+        f4 = logic.BinaryFormula(formulae[2], logic.BinaryConnective.CONJUNCTION, formulae[1])
+        self.assertEqual(f1, f2)
+        self.assertNotEqual(f1, f3)
+        self.assertNotEqual(f1, f4)
+
+
+class TestNaryFormula(unittest.TestCase):
+    def test_nary_conjunction(self):
+        triformula = logic.NaryFormula(
+            logic.BinaryConnective.CONJUNCTION,
+            [logic.PredicateExpression("c", [logic.Constant("atom1")]),
+             logic.PredicateExpression("n", [logic.Constant("atom2")]),
+             logic.BinaryFormula(logic.PredicateExpression("h", [logic.Constant("atom3")]),
+                                 logic.BinaryConnective.DISJUNCTION,
+                                 logic.PredicateExpression("c", [logic.Constant("atom3")]))])
+        self.assertTrue(triformula.is_valid())
+
+    def test_nary_implication(self):
+        # should fail, implications have to be binary
+        with self.assertRaises(AssertionError):
+            logic.NaryFormula(
+                logic.BinaryConnective.IMPLICATION,
+                [logic.PredicateExpression("c", [logic.Constant("atom1")]),
+                 logic.PredicateExpression("n", [logic.Constant("atom2")]),
+                 logic.BinaryFormula(
+                     logic.PredicateExpression("h", [logic.Constant("atom3")]),
+                     logic.BinaryConnective.DISJUNCTION,
+                     logic.PredicateExpression("c", [logic.Constant("atom3")]))])
+
+
+class TestOperatorOverloading(unittest.TestCase):
+
+    def test_negation(self):
+        formula = logic.PredicateExpression("abc", [logic.Variable("x")])
+        negated_formula = logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula)
+        self.assertEqual(negated_formula, ~formula)
+
+    def test_conjunction_disjunction(self):
+        p1 = logic.PredicateExpression("abc", [logic.Variable("x")])
+        p2 = logic.PredicateExpression("def", [logic.Variable("y")])
+        p3 = logic.PredicateExpression("ghi", [logic.Variable("z")])
+        formula = logic.BinaryFormula(
+            p1, logic.BinaryConnective.CONJUNCTION,
+            logic.BinaryFormula(p2, logic.BinaryConnective.DISJUNCTION, p3))
+        self.assertEqual(formula, p1 & (p2 | p3))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_logic/test_logic_utils.py
+++ b/tests/test_logic/test_logic_utils.py
@@ -1,0 +1,166 @@
+import unittest
+from gavel.logic import logic, logic_utils
+
+
+class TestFormulaUtils(unittest.TestCase):
+    def test_get_vars_in_formula(self):
+        formula = logic.NaryFormula(
+            logic.BinaryConnective.CONJUNCTION,
+            [logic.PredicateExpression("c", [logic.Variable("x")]),
+             logic.PredicateExpression("n", [logic.Constant("atom2")]),
+             logic.BinaryFormula(logic.PredicateExpression("h", [logic.Constant("k"), logic.Variable("z")]),
+                                 logic.BinaryConnective.DISJUNCTION,
+                                 logic.PredicateExpression("c", [logic.Variable("x")]))])
+        variables = logic_utils.get_vars_in_formula(formula)
+        self.assertTrue(logic.Variable("x") in variables)
+        self.assertFalse(logic.Variable("k") in variables)  # k is a constant
+        self.assertTrue(logic.Variable("z") in variables)
+
+    def test_flatten_formula(self):
+        formula = logic.BinaryFormula(
+            logic.BinaryFormula(
+                logic.PredicateExpression("abc", [logic.Variable("x")]),
+                logic.BinaryConnective.CONJUNCTION,
+                logic.PredicateExpression("def", [logic.Variable("y")])
+            ),
+            logic.BinaryConnective.CONJUNCTION,
+            logic.NaryFormula(logic.BinaryConnective.CONJUNCTION, [
+                logic.NaryFormula(logic.BinaryConnective.CONJUNCTION, [
+                    logic.PredicateExpression("ghi", [logic.Constant("a")])
+                ]),
+                logic.BinaryFormula(
+                    logic.PredicateExpression("abc", [logic.Variable("x")]),
+                    logic.BinaryConnective.CONJUNCTION,
+                    logic.PredicateExpression("def", [logic.Variable("y")])
+                ),
+                logic.NaryFormula(logic.BinaryConnective.DISJUNCTION, [
+                    logic.PredicateExpression("ghi", [logic.Constant("a")]),
+                    logic.PredicateExpression("jkl", [logic.Constant("b")])
+                ])
+            ])
+        )
+        flattened = logic_utils.binary_to_nary(formula, logic.BinaryConnective.CONJUNCTION)
+        # result should be a n-ary formula
+        self.assertTrue(isinstance(flattened, logic.NaryFormula))
+        # formula should not have conjunctions in layer below
+        self.assertFalse(any(isinstance(f, logic.BinaryFormula)
+                             or (isinstance(f, logic.NaryFormula) and f.operator == logic.BinaryConnective.CONJUNCTION)
+                             for f in flattened.formulae))
+        # don't flatten disjunction
+        self.assertTrue(any(isinstance(f, logic.NaryFormula) and f.operator == logic.BinaryConnective.DISJUNCTION
+                        for f in flattened.formulae))
+
+    def test_substitute_var_in_formula(self):
+        for formula in [logic.PredicateExpression("abc", [logic.Variable("X"), logic.Variable("Y")]),
+                        logic.NaryFormula(logic.BinaryConnective.CONJUNCTION, [
+                            logic.NaryFormula(logic.BinaryConnective.CONJUNCTION, [
+                                logic.PredicateExpression("ghi", [logic.Variable("X")])
+                            ]),
+                            logic.BinaryFormula(
+                                logic.PredicateExpression("abc", [logic.Variable("X")]),
+                                logic.BinaryConnective.CONJUNCTION,
+                                logic.PredicateExpression("def", [logic.Variable("Y")])
+                            ),
+                            logic.NaryFormula(logic.BinaryConnective.DISJUNCTION, [
+                                logic.PredicateExpression("ghi", [logic.Constant("a")]),
+                                logic.PredicateExpression("jkl", [logic.Variable("X")])
+                            ])
+                        ])]:
+            new_constant = logic.Constant("c1")
+            substituted = logic_utils.substitute_var_in_formula(formula, logic.Variable("X"), new_constant)
+            self.assertFalse(logic.Variable("X") in logic_utils.get_vars_in_formula(substituted))
+            self.assertTrue("c1" in substituted.symbols())
+            (self.assertTrue(logic.Variable("Y") in logic_utils.get_vars_in_formula(substituted),
+                             f"Found only variables {[str(var) for var in logic_utils.get_vars_in_formula(substituted)]}"
+                             f" in formula {substituted}"))
+
+    def test_operator_overloading(self):
+        formula = logic.PredicateExpression("abc", [logic.Constant("m")])
+        negated_formula = ~formula
+        self.assertTrue(isinstance(negated_formula, logic.UnaryFormula))
+        self.assertEqual(str(negated_formula), str(logic.UnaryFormula(logic.UnaryConnective.NEGATION, formula)))
+
+    def testNNF(self):
+        formula_eq = logic.UnaryFormula(
+            logic.UnaryConnective.NEGATION,
+            logic.BinaryFormula(logic.Variable("x"), logic.BinaryConnective.EQ, logic.Variable("y")))
+
+        formula_biimp = logic.UnaryFormula(
+            logic.UnaryConnective.NEGATION,
+            logic.BinaryFormula(
+                logic.PredicateExpression("wierdly_similar", [logic.Variable("x"), logic.Variable("y")]),
+                logic.BinaryConnective.BIIMPLICATION,
+                logic.UnaryFormula(
+                    logic.UnaryConnective.NEGATION,
+                    logic.BinaryFormula(logic.Variable("x"), logic.BinaryConnective.EQ, logic.Variable("y"))),
+            )
+        )
+
+        formula_combination = logic.UnaryFormula(
+            logic.UnaryConnective.NEGATION,
+            logic.QuantifiedFormula(
+                logic.Quantifier.UNIVERSAL,
+                [logic.Variable("x"), logic.Variable("y")],
+                logic.BinaryFormula(
+                    logic.PredicateExpression("wierdly_similar", [logic.Variable("x"), logic.Variable("y")]),
+                    logic.BinaryConnective.BIIMPLICATION,
+                    logic.BinaryFormula(
+                        logic.UnaryFormula(
+                            logic.UnaryConnective.NEGATION,
+                            logic.BinaryFormula(logic.Variable("x"), logic.BinaryConnective.EQ, logic.Variable("y"))),
+                        logic.BinaryConnective.CONJUNCTION,
+                        logic.BinaryFormula(
+                            logic.BinaryFormula(
+                                logic.PredicateExpression("wierd", [logic.Variable("x")]),
+                                logic.BinaryConnective.DISJUNCTION,
+                                logic.UnaryFormula(
+                                    logic.UnaryConnective.NEGATION,
+                                    logic.PredicateExpression("normal", [logic.Variable("x")]))
+                            ),
+                            logic.BinaryConnective.IMPLICATION,
+                            logic.PredicateExpression("wierd", [logic.Variable("y")]),
+                        )
+                    )
+                )
+            )
+        )
+
+        for formula in [formula_eq, formula_biimp, formula_combination]:
+            print("Formula:", formula)
+            formula = logic_utils.convert_to_nnf(formula)
+            print("Formula in NNF:", formula)
+            # weak assertion, does not test correct propagation of negation
+            self.assertNotIsInstance(formula, logic.UnaryFormula)
+
+    def testCNF(self):
+        formula = logic.BinaryFormula(
+            logic.PredicateExpression("wierdly_similar", [logic.Variable("x"), logic.Variable("y")]),
+            logic.BinaryConnective.DISJUNCTION,
+            logic.NaryFormula(logic.BinaryConnective.CONJUNCTION, [
+                logic.UnaryFormula(logic.UnaryConnective.NEGATION,
+                                   logic.BinaryFormula(logic.Variable("x"), logic.BinaryConnective.EQ,
+                                                       logic.Variable("y"))),
+                logic.BinaryFormula(
+                    logic.PredicateExpression("wierd", [logic.Variable("x")]),
+                    logic.BinaryConnective.DISJUNCTION,
+                    logic.UnaryFormula(
+                        logic.UnaryConnective.NEGATION,
+                        logic.PredicateExpression("normal", [logic.Variable("x")]))
+                ),
+                logic.PredicateExpression("wierd", [logic.Variable("y")]),
+            ])
+        )
+        print("Formula:", formula)
+        formula = logic_utils.convert_to_cnf(formula)
+        print("Formula in CNF:", formula)
+        self.assertIsInstance(formula, logic.NaryFormula)
+        self.assertEqual(formula.operator, logic.BinaryConnective.CONJUNCTION)
+        for clause in formula.formulae:
+            self.assertIsInstance(clause, logic.NaryFormula)
+            self.assertEqual(clause.operator, logic.BinaryConnective.DISJUNCTION)
+            for literal in clause.formulae:
+                self.assertTrue(logic_utils.is_literal(literal))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_logic/test_logic_utils.py
+++ b/tests/test_logic/test_logic_utils.py
@@ -17,6 +17,7 @@ class TestFormulaUtils(unittest.TestCase):
         self.assertTrue(logic.Variable("z") in variables)
 
     def test_flatten_formula(self):
+        # ((abc & def) & ((ghi & (abc & def) & (ghi | jkl))))
         formula = logic.BinaryFormula(
             logic.BinaryFormula(
                 logic.PredicateExpression("abc", [logic.Variable("x")]),
@@ -39,16 +40,15 @@ class TestFormulaUtils(unittest.TestCase):
                 ])
             ])
         )
-        flattened = logic_utils.binary_to_nary(formula, logic.BinaryConnective.CONJUNCTION)
         # result should be a n-ary formula
-        self.assertTrue(isinstance(flattened, logic.NaryFormula))
+        self.assertTrue(isinstance(logic_utils.binary_to_nary(formula, logic.BinaryConnective.CONJUNCTION), logic.NaryFormula))
         # formula should not have conjunctions in layer below
         self.assertFalse(any(isinstance(f, logic.BinaryFormula)
                              or (isinstance(f, logic.NaryFormula) and f.operator == logic.BinaryConnective.CONJUNCTION)
-                             for f in flattened.formulae))
+                             for f in logic_utils.binary_to_nary(formula, logic.BinaryConnective.CONJUNCTION).formulae))
         # don't flatten disjunction
         self.assertTrue(any(isinstance(f, logic.NaryFormula) and f.operator == logic.BinaryConnective.DISJUNCTION
-                        for f in flattened.formulae))
+                        for f in logic_utils.binary_to_nary(formula, logic.BinaryConnective.CONJUNCTION).formulae))
 
     def test_substitute_var_in_formula(self):
         for formula in [logic.PredicateExpression("abc", [logic.Variable("X"), logic.Variable("Y")]),

--- a/tests/test_logic/test_logic_utils.py
+++ b/tests/test_logic/test_logic_utils.py
@@ -71,7 +71,8 @@ class TestFormulaUtils(unittest.TestCase):
             self.assertFalse(logic.Variable("X") in logic_utils.get_vars_in_formula(substituted))
             self.assertTrue("c1" in substituted.symbols())
             (self.assertTrue(logic.Variable("Y") in logic_utils.get_vars_in_formula(substituted),
-                             f"Found only variables {[str(var) for var in logic_utils.get_vars_in_formula(substituted)]}"
+                             f"Found only variables "
+                             f"{[str(var) for var in logic_utils.get_vars_in_formula(substituted)]}"
                              f" in formula {substituted}"))
 
     def test_operator_overloading(self):
@@ -88,7 +89,7 @@ class TestFormulaUtils(unittest.TestCase):
         formula_biimp = logic.UnaryFormula(
             logic.UnaryConnective.NEGATION,
             logic.BinaryFormula(
-                logic.PredicateExpression("wierdly_similar", [logic.Variable("x"), logic.Variable("y")]),
+                logic.PredicateExpression("weirdly_similar", [logic.Variable("x"), logic.Variable("y")]),
                 logic.BinaryConnective.BIIMPLICATION,
                 logic.UnaryFormula(
                     logic.UnaryConnective.NEGATION,
@@ -102,7 +103,7 @@ class TestFormulaUtils(unittest.TestCase):
                 logic.Quantifier.UNIVERSAL,
                 [logic.Variable("x"), logic.Variable("y")],
                 logic.BinaryFormula(
-                    logic.PredicateExpression("wierdly_similar", [logic.Variable("x"), logic.Variable("y")]),
+                    logic.PredicateExpression("weirdly_similar", [logic.Variable("x"), logic.Variable("y")]),
                     logic.BinaryConnective.BIIMPLICATION,
                     logic.BinaryFormula(
                         logic.UnaryFormula(
@@ -111,14 +112,14 @@ class TestFormulaUtils(unittest.TestCase):
                         logic.BinaryConnective.CONJUNCTION,
                         logic.BinaryFormula(
                             logic.BinaryFormula(
-                                logic.PredicateExpression("wierd", [logic.Variable("x")]),
+                                logic.PredicateExpression("weird", [logic.Variable("x")]),
                                 logic.BinaryConnective.DISJUNCTION,
                                 logic.UnaryFormula(
                                     logic.UnaryConnective.NEGATION,
                                     logic.PredicateExpression("normal", [logic.Variable("x")]))
                             ),
                             logic.BinaryConnective.IMPLICATION,
-                            logic.PredicateExpression("wierd", [logic.Variable("y")]),
+                            logic.PredicateExpression("weird", [logic.Variable("y")]),
                         )
                     )
                 )
@@ -134,20 +135,20 @@ class TestFormulaUtils(unittest.TestCase):
 
     def testCNF(self):
         formula = logic.BinaryFormula(
-            logic.PredicateExpression("wierdly_similar", [logic.Variable("x"), logic.Variable("y")]),
+            logic.PredicateExpression("weirdly_similar", [logic.Variable("x"), logic.Variable("y")]),
             logic.BinaryConnective.DISJUNCTION,
             logic.NaryFormula(logic.BinaryConnective.CONJUNCTION, [
                 logic.UnaryFormula(logic.UnaryConnective.NEGATION,
                                    logic.BinaryFormula(logic.Variable("x"), logic.BinaryConnective.EQ,
                                                        logic.Variable("y"))),
                 logic.BinaryFormula(
-                    logic.PredicateExpression("wierd", [logic.Variable("x")]),
+                    logic.PredicateExpression("weird", [logic.Variable("x")]),
                     logic.BinaryConnective.DISJUNCTION,
                     logic.UnaryFormula(
                         logic.UnaryConnective.NEGATION,
                         logic.PredicateExpression("normal", [logic.Variable("x")]))
                 ),
-                logic.PredicateExpression("wierd", [logic.Variable("y")]),
+                logic.PredicateExpression("weird", [logic.Variable("y")]),
             ])
         )
         print("Formula:", formula)


### PR DESCRIPTION
I added some features to the logic that were necessary / convenient for the chemlog project, but might also become useful in other applications:
- syntactic equality checks (e.g., `PredicateExpression("abc", [Variable("x")]) == PredicateExpression("abc", [Variable("x")])` should hold even though two separate instances of `PredicateExpression` were created)
- n-ary operators as shortcut for chain of associative binary operators (mainly disjunction, conjunction)
- operator overloading for built-in operators `&`, `|`, `~` (conjunction, disjunction, negation)
- detection of all variables in a nested formula, substitution of specific variables in a nested formula
- NNF, CNF, biimplication and implication conversions
- tests