### PR TITLE
fix cnf conversion & variable equality

### DIFF
--- a/src/gavel/logic/logic.py
+++ b/src/gavel/logic/logic.py
@@ -244,6 +244,8 @@ class Variable(TermExpression):
         return re.match("[A-Z]\w*", self.symbol)
 
     def __eq__(self, other):
+        if not isinstance(other, Variable):
+            return False
         return self.symbol == other.symbol
 
     def __hash__(self):

--- a/src/gavel/logic/logic_utils.py
+++ b/src/gavel/logic/logic_utils.py
@@ -311,8 +311,8 @@ def convert_to_cnf(formula: logic.LogicExpression) -> logic.NaryFormula:
             # nested conjunctions: resolve
             if clause.operator == logic.BinaryConnective.CONJUNCTION:
                 if isinstance(clause, logic.BinaryFormula):
-                    unprocessed_clauses.put(formula.left)
-                    unprocessed_clauses.put(formula.right)
+                    unprocessed_clauses.put(clause.left)
+                    unprocessed_clauses.put(clause.right)
                 else:
                     assert isinstance(clause, logic.NaryFormula)
                     for f in clause.formulae:


### PR DESCRIPTION
In the CNF conversion, the original formula has been used instead of the currently relevant subformula. This leads to an infinite loop it the formula contains several levels of conjunctions.

Also, the equality for variables didn't check if the `other` is also a Variable (if not it raises an error trying to access the non-existent `other.symbol`)