### PR TITLE
fix parentheses for n-ary formulas

### DIFF
--- a/src/gavel/logic/logic.py
+++ b/src/gavel/logic/logic.py
@@ -448,6 +448,8 @@ class NaryFormula(LogicExpression):
     """Shortcut for a chain of binary formulas with the same, associative operator"""
     __visit_name__ = "nary_formula"
 
+    requires_parens = True
+
     def __init__(self, operator: BinaryConnective, formulae: Iterable[LogicExpression]):
         assert operator.is_associative()
         self.operator = operator


### PR DESCRIPTION
I had the following issue while compiling to TPTP:

I tried to compile the formula
```
(A | B) & C
```
where `A | B` is a n-ary disjunction. This compiles to
```
A | B & C
```
in TPTP. 

This does not happen if `A | B` is a binary formula. The fix is to set the `requires_parens` for n-ary formulas.