### PR TITLE
add 0-ary predicate expressions to TPTP parser

### DIFF
--- a/src/gavel/dialects/tptp/parser.py
+++ b/src/gavel/dialects/tptp/parser.py
@@ -189,18 +189,26 @@ class TPTPTransformer(Transformer):
                 )
         else:
             assert len(obj.children) == 1 and isinstance(obj.children[0], str)
-            if is_defined:
-                if c0 == "$true":
-                    return logic.DefinedConstant(logic.PredefinedConstant.VERUM)
-                elif c0 == "$false":
-                    return logic.DefinedConstant(logic.PredefinedConstant.FALSUM)
+            if term_level:
+                if is_defined:
+                    if c0 == "$true":
+                        return logic.DefinedConstant(logic.PredefinedConstant.VERUM)
+                    elif c0 == "$false":
+                        return logic.DefinedConstant(logic.PredefinedConstant.FALSUM)
+                    else:
+                        return logic.DefinedConstant(self.visit(c0))
                 else:
-                    return logic.DefinedConstant(self.visit(c0))
+                
+                    if c0[0] == '"':
+                        return logic.DistinctObject(c0)
+                    else:
+                        return logic.Constant(c0)
             else:
-                if c0[0] == '"':
-                    return logic.DistinctObject(c0)
-                else:
-                    return logic.Constant(c0)
+                p = self._DEFINED_PREDICATE_MAP.get(c0, c0) if is_defined else c0
+                return logic.PredicateExpression(
+                    predicate=p,
+                    arguments=[],
+                )
 
     def visit_decimal_number(self, obj, **kwargs):
         return logic.DefinedConstant(obj)


### PR DESCRIPTION
As explained in https://github.com/gavel-tool/python-gavel/pull/23#issuecomment-3779633343, the TPTP does mistake 0-ary predicates for constants. However, we can differentiate them cleanly with the help of `term_level`.

This is an addition to #23